### PR TITLE
Delete or set false for doing key by catch case

### DIFF
--- a/lib/do.js
+++ b/lib/do.js
@@ -30,10 +30,11 @@ async function Do (key, func) {
     data = await func()
   } catch (e) {
     bus.emit('sf_' + key, e, data)
+    delete doing[key]
     throw e
   }
   bus.emit('sf_' + key, null, data)
-  doing[key] = false
+  delete doing[key]
   return data
 }
 


### PR DESCRIPTION
If you don't `Delete` or `set false` for doing[key] from `catch`, It will never the end next time.

example:
```js
await Do("samekey",async ()=>{
  throw "something error"
})
// second time
Do("samekey",async ()=>{
  ...
}) // never the end
```

And please update it to NPM package. Thx